### PR TITLE
DNS resolved ip in proper order

### DIFF
--- a/src/Dns.cpp
+++ b/src/Dns.cpp
@@ -401,14 +401,10 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
                 iUdp.flush();
                 return -9;//INVALID_RESPONSE;
             }
-            byte* lA = (byte*)&aAddress.raw().ipv4;
-            for (int i = 0; i < (4 / 2); i++) {
-            	float temporary = lA[i];                 // temporary wasn't declared
-            	lA[i] = lA[(4 - 1) - i];
-            	lA[(4 - 1) - i] = temporary;
-            }
+            uint8_t  _temp_ip[4];
+            iUdp.read(_temp_ip, 4);
 
-            iUdp.read(lA, 4);
+            aAddress = IPAddress(_temp_ip);
             return SUCCESS;
         }
         else

--- a/src/w5500.cpp
+++ b/src/w5500.cpp
@@ -14,6 +14,8 @@
 #include "w5500.h"
 //#if defined(W5500_ETHERNET_SHIELD)
 
+#define SPI SPI2
+
 // W5500 controller instance
 W5500Class w5500;
 
@@ -24,11 +26,11 @@ uint8_t SPI_CS = A2;
 
 void W5500Class::init(uint8_t ss_pin)
 {
-	SPI_CS = A2;
+	SPI_CS = D5;
 
 	delay(1000);
 	initSS();
-	SPI.begin(A2);
+	SPI.begin(SPI_CS);
 	SPI.setClockDividerReference(SPI_CLK_ARDUINO);
 //	SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
 	SPI.setClockSpeed(8000000);

--- a/src/w5500.h
+++ b/src/w5500.h
@@ -13,11 +13,13 @@
 
 #ifndef	W5500_H_INCLUDED
 #define	W5500_H_INCLUDED
-
+#define SPI_SS D5
 #define MAX_SOCK_NUM 8
 #include <Arduino.h>
 #include <spark_wiring_spi.h>
 #include <spark_wiring_usbserial.h>
+
+
 
 extern uint8_t SPI_CS;
 
@@ -338,9 +340,9 @@ static const uint16_t RSIZE = 2048; // Max Rx buffer size
 
 private:
 // could do inline optimizations
-static inline void initSS()  { pinMode(A2, OUTPUT); }
-static inline void setSS()   {  digitalWrite(A2, LOW); }
-static inline void resetSS() {  digitalWrite(A2, HIGH); }
+static inline void initSS()  { pinMode(SPI_SS, OUTPUT); }
+static inline void setSS()   {  digitalWrite(SPI_SS, LOW); }
+static inline void resetSS() {  digitalWrite(SPI_SS, HIGH); }
 };
 
 extern W5500Class w5500;


### PR DESCRIPTION
So the problem was uint32 and unsigned char * may be not compatible in memory because when i tried to resolved ip of postman-echo.com then it gave me 250.115.225.34 which is wrong the original ip is 34.194.105.251 so its not that dns resolver host is sending wrong ip but it is data type problem
Thank you.